### PR TITLE
fix: correct policy code feature concatenation order

### DIFF
--- a/deploy/deploy_real/deploy_real_go2w_DWAQ.py
+++ b/deploy/deploy_real/deploy_real_go2w_DWAQ.py
@@ -282,7 +282,7 @@ class Controller:
 
         print(vel)
         print(latent)
-        code = torch.cat((vel, latent), dim = -1)
+        code = torch.cat((latent, vel), dim = -1)
         print(code)
         tmpp = torch.from_numpy(self.obs)
         obs_all = torch.cat((code, tmpp), dim = -1)


### PR DESCRIPTION
Switch code assembly to concatenate latent before velocity so the runtime input layout matches the expected model feature order.
code from (vel, latent) to (latent, vel)

Made-with: wxx